### PR TITLE
disable gzip compression

### DIFF
--- a/src/ttrss.nginx.conf
+++ b/src/ttrss.nginx.conf
@@ -12,7 +12,7 @@ http {
 
     sendfile          on;
     keepalive_timeout 65;
-    gzip              on;
+    gzip              off;
 
     server {
         listen 80;


### PR DESCRIPTION
If it is enabled, reserve proxy with SSL will also serve compressed data, which should be disabled after BREACH, CRIME attack.