### PR TITLE
log exception when dbcheckdb failed

### DIFF
--- a/src/configure-db.php
+++ b/src/configure-db.php
@@ -122,6 +122,7 @@ function dbcheckdb($config)
         return true;
     }
     catch (PDOException $e) {
+        echo $e;
         return false;
     }
 }


### PR DESCRIPTION
user will change compose file at their will, and it may cause db check fail, log fail reason is necessary.

in fact, it cause me 1 hour to find out why it fails...