### PR TITLE
fix: postgres volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - POSTGRES_PASSWORD=ttrss # please change the password
     volumes:
-      - ~/postgres/data/:/var/lib/postgresql/ # persist postgres data to ~/postgres/data/ on the host
+      - ~/postgres/data/:/var/lib/postgresql/data # persist postgres data to ~/postgres/data/ on the host
     restart: always
 
   service.rss:


### PR DESCRIPTION
postgres 按照 PGDATA 环境变量指定的路径存储数据，PGDATA 默认值为 `/var/lib/postgresql/data`，
而 postgres 的 [Dockerfile](https://github.com/docker-library/postgres/blob/34df4665bfdccf28deac2ed2924127b94489a576/12/Dockerfile#L169) 创建了`VOLUME /var/lib/postgresql/data`，按照更改前的 mount 配置，数据实际存储在了 docker 自行创建的 volume 下面 
![image.png](https://i.loli.net/2019/12/02/AGoIBeYXPt5Ta1g.png)
![image.png](https://i.loli.net/2019/12/02/VUOYe2CtWKXbi4x.png)
我们自己指定的宿主机目录实际是空的
![image.png](https://i.loli.net/2019/12/02/P29ubLT6RMeJjOE.png)
每次 docker-compose 重启，docker 都会重新生成一个 volume 挂载  `/var/lib/postgresql/data`，导致原有数据”消失不见“