### PR TITLE
fix: use postgres as default dbname in dbcheckconn

### DIFF
--- a/src/configure-db.php
+++ b/src/configure-db.php
@@ -79,7 +79,7 @@ function error($text)
 function dbconnect($config)
 {
     $map = array('host' => 'HOST', 'port' => 'PORT');
-    $dsn = 'pgsql:';
+    $dsn = 'pgsql:dbname=postgres;';
     foreach ($map as $d => $h) {
         if (isset($config['DB_' . $h])) {
             $dsn .= $d . '=' . $config['DB_' . $h] . ';';
@@ -97,6 +97,7 @@ function dbcheckconn($config)
         return true;
     }
     catch (PDOException $e) {
+        echo $e;
         return false;
     }
 }


### PR DESCRIPTION
If not special the dbname, postgres will use username as the default
database and always fails.

So the general method to initialize ttrss database is just create a
postgres user with creating table permission and everything will be fine:

$ docker exec -ti postgres createuser --createdb --pwprompt ttrss

---

我这里已经有一个postgres服务在跑了，启动ttrss的时候发现无法初始化数据库，用户名和密码都正确。经过调试发现是由于判断数据库能否连接时没有指定`dbname`导致，因为postgres默认连接到用户名同名的database而该database并不存在所以总是检测失败。

postgres默认存在`postgres,template0,template1`三个database，使用`postgres`作为dbname可以修复该问题。
