### PR TITLE
feat: remove default plugin fever, add remove-iframe-sandbox docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -202,8 +202,6 @@ Fetch fulltext of articles via a self-hosted Mercury Parser API. A separate Merc
 
 Provide Fever API simulate.
 
-**Plugin is enabled as a system plugin by default.**
-
 #### Steps
 
 1. Enable API in preference
@@ -253,6 +251,12 @@ Refer to [Feediron](https://github.com/feediron/ttrss_plugin-feediron) for more 
 Provide the ability to configure proxy, user-agent and SSL certificate verification on a per feed basis.
 
 Refer to [Options per Feed](https://github.com/sergey-dryabzhinsky/options_per_feed) for more details.
+
+### [Remove iframe sandbox](https://github.com/DIYgod/ttrss-plugin-remove-iframe-sandbox)
+
+Remove sandbox attribute on iframes, to support embed video in feeds.
+
+Refer to [Remove iframe sandbox](https://github.com/DIYgod/ttrss-plugin-remove-iframe-sandbox)。
 
 ## Themes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -254,7 +254,7 @@ Refer to [Options per Feed](https://github.com/sergey-dryabzhinsky/options_per_f
 
 ### [Remove iframe sandbox](https://github.com/DIYgod/ttrss-plugin-remove-iframe-sandbox)
 
-Remove sandbox attribute on iframes, to support embed video in feeds.
+Remove the sandbox attribute on iframes, thus enabling playback of embedded video in feeds.
 
 Refer to [Remove iframe sandbox](https://github.com/DIYgod/ttrss-plugin-remove-iframe-sandbox)。
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -202,8 +202,6 @@ sameersbn/postgresql 已经完成了它的使命，pg_trgm 扩展已经不再需
 
 提供 Fever API 支持。
 
-**该插件默认作为系统插件启用。**
-
 #### 设置步骤
 
 1. 在设置中启用 API。
@@ -253,6 +251,12 @@ Demo 服务器，可用性不做任何保证：[https://opencc.henry.wang](https
 提供单独为源地址配置代理、user-agent 以及 SSL 证书验证的能力。
 
 使用指南见 [Options per Feed](https://github.com/sergey-dryabzhinsky/options_per_feed)。
+
+### [Remove iframe sandbox](https://github.com/DIYgod/ttrss-plugin-remove-iframe-sandbox)
+
+移除 iframe 上的 sandbox 属性，以支持 feed 中直接播放嵌入视频。
+
+使用指南见 [Remove iframe sandbox](https://github.com/DIYgod/ttrss-plugin-remove-iframe-sandbox)。
 
 ## 主题
 

--- a/src/configure-db.php
+++ b/src/configure-db.php
@@ -11,7 +11,7 @@ $config['DB_PORT'] = env('DB_PORT', 5432);
 $config['DB_NAME'] = env('DB_NAME', 'ttrss');
 $config['DB_USER'] = env('DB_USER');
 $config['DB_PASS'] = env('DB_PASS');
-$config['PLUGINS'] = env('ENABLE_PLUGINS', 'auth_internal,fever');
+$config['PLUGINS'] = env('ENABLE_PLUGINS', 'auth_internal');
 $config['SESSION_COOKIE_LIFETIME'] = env('SESSION_COOKIE_LIFETIME', 24) * 3600;
 $config['SINGLE_USER_MODE'] = env('SINGLE_USER_MODE', false);
 


### PR DESCRIPTION
移除 fever 默认作为系统插件启用，是因为发现作为系统插件启用时，用户插件经常不会在 fever api 中生效

而且 fever 不是所有人都需要，默认作为系统插件启用也不太合适