### PR TITLE
feat: define networks for the stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -136,4 +136,19 @@ RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases
 
 EXPOSE 80
 
+# Database default settings
+ENV DB_HOST=database.postgres
+ENV DB_PORT=5432
+ENV DB_USER=postgres
+ENV DB_PASS=ttrss
+ENV DB_NAME=ttrss
+
+# Some default settings
+ENV SELF_URL_PATH=http://localhost:181/
+ENV ENABLE_PLUGINS=auth_internal,fever
+ENV SESSION_COOKIE_LIFETIME=24
+ENV SINGLE_USER_MODE=false
+ENV LOG_DESTINATION=sql
+ENV FEED_LOG_QUIET=false
+
 ENTRYPOINT ["sh", "/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     container_name: postgres
     environment:
       - POSTGRES_PASSWORD=ttrss # please change the password
-    volumes:
-      - ~/postgres/data/:/var/lib/postgresql/data # persist postgres data to ~/postgres/data/ on the host
+    networks:
+      - database_only
     restart: always
 
   service.rss:
@@ -23,6 +23,10 @@ services:
       - DB_PASS=ttrss # please change the password
       - ENABLE_PLUGINS=auth_internal,fever # auth_internal is required. Plugins enabled here will be enabled for all users as system plugins
       - FEED_LOG_QUIET=true
+    networks:
+      - public_access
+      - service_only
+      - database_only
     stdin_open: true
     tty: true
     restart: always
@@ -30,8 +34,8 @@ services:
   service.mercury: # set Mercury Parser API endpoint to `service.mercury:3000` on TTRSS plugin setting page
     image: wangqiru/mercury-parser-api:latest
     container_name: mercury
-    expose:
-      - 3000
+    networks:
+      - service_only
     restart: always
 
   service.opencc: # set OpenCC API endpoint to `service.opencc:3000` on TTRSS plugin setting page
@@ -39,8 +43,8 @@ services:
     container_name: opencc
     environment:
       - NODE_ENV=production
-    expose:
-      - 3000
+    networks:
+      - service_only
     restart: always
 
   # utility.watchtower:
@@ -52,3 +56,10 @@ services:
   #     - WATCHTOWER_CLEANUP=true
   #     - WATCHTOWER_POLL_INTERVAL=86400
   #   restart: always
+
+networks:
+  public_access: # Provide the access for ttrss UI
+  service_only: # Provide the communication network between services only
+    internal: true
+  database_only: # Provide the communication between ttrss and database only
+    internal: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,5 @@
 version: "3"
 services:
-  database.postgres:
-    image: postgres:13-alpine
-    container_name: postgres
-    environment:
-      - POSTGRES_PASSWORD=ttrss # please change the password
-    networks:
-      - database_only
-    restart: always
-
   service.rss:
     image: wangqiru/ttrss:latest
     container_name: ttrss
@@ -16,13 +7,7 @@ services:
       - 181:80
     environment:
       - SELF_URL_PATH=http://localhost:181/ # please change to your own domain
-      - DB_HOST=database.postgres
-      - DB_PORT=5432
-      - DB_NAME=ttrss
-      - DB_USER=postgres
-      - DB_PASS=ttrss # please change the password
-      - ENABLE_PLUGINS=auth_internal,fever # auth_internal is required. Plugins enabled here will be enabled for all users as system plugins
-      - FEED_LOG_QUIET=true
+      - DB_PASS=ttrss # use the same password defined in `database.postgres`
     networks:
       - public_access
       - service_only
@@ -45,6 +30,17 @@ services:
       - NODE_ENV=production
     networks:
       - service_only
+    restart: always
+
+  database.postgres:
+    image: postgres:13-alpine
+    container_name: postgres
+    environment:
+      - POSTGRES_PASSWORD=ttrss # feel free to change the password
+    volumes:
+      - ~/postgres/data/:/var/lib/postgresql/data # persist postgres data to ~/postgres/data/ on the host
+    networks:
+      - database_only
     restart: always
 
   # utility.watchtower:

--- a/src/configure-db.php
+++ b/src/configure-db.php
@@ -5,18 +5,22 @@ $confpath = '/var/www/config.php';
 
 $config = array();
 
-$config['SELF_URL_PATH'] = env('SELF_URL_PATH', 'http://localhost');
+$config['SELF_URL_PATH'] = env('SELF_URL_PATH');
+
 $config['DB_TYPE'] = 'pgsql';
-$config['DB_HOST'] = env('DB_HOST', 'database.postgres');
-$config['DB_PORT'] = env('DB_PORT', 5432);
-$config['DB_NAME'] = env('DB_NAME', 'ttrss');
+$config['DB_HOST'] = env('DB_HOST');
+$config['DB_PORT'] = env('DB_PORT');
+$config['DB_NAME'] = env('DB_NAME');
+
 $config['DB_USER'] = env('DB_USER');
 $config['DB_PASS'] = env('DB_PASS');
-$config['PLUGINS'] = env('ENABLE_PLUGINS', 'auth_internal');
-$config['SESSION_COOKIE_LIFETIME'] = env('SESSION_COOKIE_LIFETIME', 24) * 3600;
-$config['SINGLE_USER_MODE'] = env('SINGLE_USER_MODE', false);
-$config['LOG_DESTINATION'] = env('LOG_DESTINATION', 'sql');
-$config['FEED_LOG_QUIET'] = env('FEED_LOG_QUIET', false);
+
+$config['PLUGINS'] = env('ENABLE_PLUGINS');
+$config['SESSION_COOKIE_LIFETIME'] = env('SESSION_COOKIE_LIFETIME') * 3600;
+$config['SINGLE_USER_MODE'] = env('SINGLE_USER_MODE');
+$config['LOG_DESTINATION'] = env('LOG_DESTINATION');
+$config['FEED_LOG_QUIET'] = env('FEED_LOG_QUIET');
+
 
 $log_daemon = '/etc/s6/update-daemon/run';
 


### PR DESCRIPTION
Use networks to confine containers, obsoleting the password change in postgres.

Also simplified docker-compose.yml, showing fewer configs by default.

Move default envs from php to Dockerfile, we all know why.

Close #200.