### PR TITLE
feat: add persistent volume for favicons

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     environment:
       - SELF_URL_PATH=http://localhost:181/ # please change to your own domain
       - DB_PASS=ttrss # use the same password defined in `database.postgres`
+    volumes:
+      - feed-icons:/var/www/feed-icons/
     networks:
       - public_access
       - service_only
@@ -52,7 +54,10 @@ services:
   #     - WATCHTOWER_CLEANUP=true
   #     - WATCHTOWER_POLL_INTERVAL=86400
   #   restart: always
-
+  
+volumes:
+  feed-icons:
+  
 networks:
   public_access: # Provide the access for ttrss UI
   service_only: # Provide the communication network between services only

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,10 +55,10 @@ services:
   #     - WATCHTOWER_CLEANUP=true
   #     - WATCHTOWER_POLL_INTERVAL=86400
   #   restart: always
-  
+
 volumes:
   feed-icons:
-  
+
 networks:
   public_access: # Provide the access for ttrss UI
   service_only: # Provide the communication network between services only


### PR DESCRIPTION
The favicons in TTRSS are not persistent after the container is destroyed and re-created. TTRSS will wait 12 hours before re-fetching those icons. Add a persistent volume can help icons survive an upgrade of the container.