### PR TITLE
feat: support php8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,11 +87,12 @@ ENV PHP_EXTENTIONS intl pcntl pgsql pdo_pgsql zip
 
 # Install dependencies
 RUN chmod -x /wait-for.sh && chmod -x /docker-entrypoint.sh \
-  && apk add --update --no-cache nginx s6 git icu-libs libpq libzip \
+  && apk add --update --no-cache nginx s6 git icu-libs libpq libzip libpng jpeg zlib libwebp \
   # https://github.com/docker-php/issues/1055#issuecomment-693370957
-  && apk add --virtual=.build-dependencies --update --no-cache icu-dev libpng-dev postgresql-dev libzip-dev \
+  && apk add --virtual=.build-dependencies --update --no-cache \
+  icu-dev libpng-dev jpeg-dev zlib-dev libwebp-dev postgresql-dev libzip-dev \
   && NPROC=$(getconf _NPROCESSORS_ONLN) \
-  && docker-php-ext-configure gd --enable-gd \
+  && docker-php-ext-configure gd --enable-gd=shared --with-jpeg --with-webp \
   && docker-php-ext-install ${PHP_EXTENTIONS} \
   && apk del .build-dependencies \
   && rm -rf /var/cache/apk/* \

--- a/src/initialize.php
+++ b/src/initialize.php
@@ -15,6 +15,8 @@ $config['DB_NAME'] = env('DB_NAME');
 $config['DB_USER'] = env('DB_USER');
 $config['DB_PASS'] = env('DB_PASS');
 
+$config['PHP_EXECUTABLE'] = '/usr/local/bin/php';
+
 $config['PLUGINS'] = env('ENABLE_PLUGINS');
 $config['SESSION_COOKIE_LIFETIME'] = env('SESSION_COOKIE_LIFETIME') * 3600;
 $config['SINGLE_USER_MODE'] = filter_var(env('SINGLE_USER_MODE'), FILTER_VALIDATE_BOOLEAN);

--- a/src/s6/php-fpm/run
+++ b/src/s6/php-fpm/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec /usr/sbin/php-fpm7 --nodaemonize
+exec /usr/local/sbin/php-fpm --nodaemonize

--- a/src/s6/update-daemon/run
+++ b/src/s6/update-daemon/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec s6-setuidgid nobody php /var/www/update_daemon2.php
+exec s6-setuidgid www-data php /var/www/update_daemon2.php

--- a/src/ttrss.nginx.conf
+++ b/src/ttrss.nginx.conf
@@ -1,6 +1,7 @@
 daemon           off;
 pid              /run/nginx.pid;
 worker_processes 1;
+user www-data www-data;
 
 events {
     worker_connections 1024;

--- a/src/ttrss.php.conf
+++ b/src/ttrss.php.conf
@@ -1,0 +1,2 @@
+user = www-data
+group = www-data


### PR DESCRIPTION
## Update to php 8
### Why

Fixes https://github.com/HenryQW/Awesome-TTRSS/issues/242. A couple of performance and security improvements.

## Use docker.io/library/php:8-fpm-alpine as the base image
### Why

[Some hardening](https://github.com/docker-library/php/blob/57143cba9161c913cae8ba0a985bc30ba35130d2/8.0/alpine3.13/fpm/Dockerfile#L57) won't exist be enforced you simply install php yourself. And it's not reasonable to implement all those again.

## Add the `docker.io/` prefix for image names
### Why

Many image registries are emerging these days (e.g. quay.io). Some, container orchistrators, e.g. podman, don't assume the images being hosted in `docker.io` by default, which is fair. Adding this prefix makes the reference more clear, and you don't have to select the registry every time.

## TODO

- The image grows to 205 MB, and that's not satisfying. Maybe we need to analyze the image in some way
- The homepage is not going to load