### PR TITLE
feat: wait for db connection

### DIFF
--- a/src/initialize.php
+++ b/src/initialize.php
@@ -28,6 +28,12 @@ $str = $config['FEED_LOG_QUIET'] ? preg_replace('/.php$/m', '.php --quiet', file
 
 file_put_contents($log_daemon, $str);
 
+// Wait for the db connection
+$i = 1;
+while (!dbcheckconn($config) && $i <= 10) {
+    sleep(3);
+    $i++;
+}
 if (dbcheckconn($config)) {
     $pdo = dbconnect($config);
 


### PR DESCRIPTION
Potentially fixes #240

The current implementation of wait-for covers too little scenarios. It fires just after the tcp port of the db is up. However, look at how long it takes until it really accepts connections:

````
PostgreSQL Database directory appears to contain a database; Skipping initialization

2021-02-17 21:21:37.048 UTC [1] LOG:  starting PostgreSQL 13.2 on x86_64-pc-linux-musl, compiled by gcc (Alpine 10.2.1_pre1) 10.2.1 20201203, 64-bit
2021-02-17 21:21:37.049 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2021-02-17 21:21:37.049 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2021-02-17 21:21:37.232 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2021-02-17 21:21:40.546 UTC [21] FATAL:  the database system is starting up
2021-02-17 21:21:40.916 UTC [1] LOG:  database system is ready to accept connections
````