### PR TITLE
feat: Add feedstatistics plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,11 @@ RUN mkdir api_newsplus && \
 ## FeedReader API
 ADD https://raw.githubusercontent.com/jangernert/FeedReader/master/data/tt-rss-feedreader-plugin/api_feedreader/init.php api_feedreader/
 
+## Feedstatistics
+RUN mkdir feedstatistics && \
+  curl -sL https://github.com/jsoares/ttrss-plugin-feedstatistics/archive/master.tar.gz | \
+  tar xzvpf - --strip-components=1 -C feedstatistics ttrss-plugin-feedstatistics-master
+
 ## Options per feed
 RUN mkdir options_per_feed && \
   curl -sL https://github.com/sergey-dryabzhinsky/options_per_feed/archive/master.tar.gz | \

--- a/docs/README.md
+++ b/docs/README.md
@@ -268,6 +268,12 @@ System plugin, enabled by adding `api_feedreader` to the environment variable **
 
 Refer to [FeedReader API](https://github.com/jangernert/FeedReader/tree/master/data/tt-rss-feedreader-plugin) for more details.
 
+### [Feedstatistics](https://github.com/DIYgod/ttrss-plugin-remove-iframe-sandbox)
+
+Provide a statistics pane to the feed preferences tab, including both a Google Reader-style one line summary and a table of statistics per feed.
+
+Refer to [Feedstatistics](https://github.com/DIYgod/ttrss-plugin-remove-iframe-sandbox) for more details.
+
 ### [News+ API](https://github.com/voidstern/tt-rss-newsplus-plugin/)
 
 Provide a faster two-way synchronization for Android App [News+](http://github.com/noinnion/newsplus/) and iOS App [Fiery Feeds](http://cocoacake.net/apps/fiery/) with TTRSS.


### PR DESCRIPTION
Plugin to provide some statistics about feeds.
I made this for myself, but if you think it can be worth to include it in your image, you can merge it.

Plugin source: https://github.com/jsoares/ttrss-plugin-feedstatistics