### PR TITLE
fix: php8 install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN chmod -x /wait-for.sh && chmod -x /docker-entrypoint.sh && apk add --update 
   php8-gd php8-mbstring php8-intl php8-xml php8-curl \
   php8-session php8-tokenizer php8-dom php8-fileinfo \
   php8-json php8-iconv php8-pcntl php8-posix php8-zip php8-exif \
-  ca-certificates && ln -s /usr/bin/php8 /usr/bin/php && rm -rf /var/cache/apk/* \
+  ca-certificates && rm -rf /var/cache/apk/* \
   # Update libiconv as the default version is too low
   && apk add gnu-libiconv=1.15-r3 --update --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.13/community/ \
   && rm -rf /var/www


### PR DESCRIPTION
Alpine 3.16 is released on 23 May.

```bash
ln -s /usr/bin/php8 /usr/bin/php
```
is no longer required for alpine 3.16