### PR TITLE
fix: build failure

### DIFF
--- a/src/s6/php-fpm/run
+++ b/src/s6/php-fpm/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec /usr/sbin/php-fpm8 --nodaemonize
+exec /usr/sbin/php-fpm81 --nodaemonize


### PR DESCRIPTION
Alpine 3.17 is released.
> DEPRECATION NOTES
>
> PHP 8.0 has been deprecated.
> https://alpinelinux.org/posts/Alpine-3.17.0-released.html

changes:
- bump `php8` to `php81` (this's why probably nightly build failed, upstream is also releasing images [on php8.1](https://dev.tt-rss.org/tt-rss/ttrss-docker-compose/blame/branch/master/app/Dockerfile))
- bump `glibc` to 2.34-r0
- add `php81-phar`, `php81-xmlwriter`, `php81-simplexml` and `php81-ctype` (follow [upstream](https://dev.tt-rss.org/tt-rss/ttrss-docker-compose/blame/branch/master/app/Dockerfile))
- update build for `glibc` (follow [upstream](https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc/blob/master/Dockerfile))

The image can be started as usual on the [latest commit](https://dev.tt-rss.org/tt-rss/tt-rss/commit/fa9c614ff144153ca1f4c0744fe0bc7d8f3a82ad).
<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/11386903/206787838-47b522bc-ea91-4df1-9177-10fa01d5e4fe.png)
</details>