### PR TITLE
feat: add Auth OIDC plugin to Awesome-TTRSS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,11 @@ RUN mkdir remove_iframe_sandbox && \
 RUN mkdir wallabag_v2 && \
   curl -sL https://github.com/joshp23/ttrss-to-wallabag-v2/archive/master.tar.gz | \
   tar xzvpf - --strip-components=2 -C wallabag_v2 ttrss-to-wallabag-v2-master/wallabag_v2
+  
+## Auth OIDC
+RUN mkdir auth_oidc && \
+  curl -sL https://dev.tt-rss.org/tt-rss/ttrss-auth-oidc/archive/master.tar.gz | \
+  tar xzvpf - --strip-components=1 -C auth_oidc ttrss-auth-oidc-master
 
 # Download themes
 WORKDIR /var/www/themes.local

--- a/docs/README.md
+++ b/docs/README.md
@@ -298,6 +298,23 @@ Save articles to Wallabag.
 
 Refer to [Wallabag v2](https://github.com/joshp23/ttrss-to-wallabag-v2)。
 
+### [Auth OIDC](https://dev.tt-rss.org/tt-rss/ttrss-auth-oidc)
+
+This is a system plugin, that allow users to connect through an oidc provider, like Keycloak, to TTRSS. 
+
+System plugin, enabled by adding `auth_oidc` to the environment variable **ENABLE_PLUGINS**.
+
+Then add the following environments variables with according values : 
+
+    ```yaml
+        AUTH_OIDC_NAME: 'IDP provider name displayed'
+        AUTH_OIDC_URL: 'https://oidc.hostname.com'
+        AUTH_OIDC_CLIENT_ID: 'test-rss'
+        AUTH_OIDC_CLIENT_SECRET: 'your-secret-token'
+    ```
+    
+Refer to [Auth OIDC](https://dev.tt-rss.org/tt-rss/ttrss-auth-oidc) for more details.
+
 ## Themes
 
 ### [Feedly](https://github.com/levito/tt-rss-feedly-theme)

--- a/src/initialize.php
+++ b/src/initialize.php
@@ -58,6 +58,10 @@ $config['SMTP_SECURE'] = env('SMTP_SECURE');
 $config['SMTP_SKIP_CERT_CHECKS'] = env('SMTP_SKIP_CERT_CHECKS');
 $config['SMTP_CA_FILE'] = env('SMTP_CA_FILE');
 $config['NGINX_XACCEL_PREFIX'] = env('NGINX_XACCEL_PREFIX');
+$config['AUTH_OIDC_NAME'] = env('AUTH_OIDC_NAME');
+$config['AUTH_OIDC_URL'] = env('AUTH_OIDC_URL');
+$config['AUTH_OIDC_CLIENT_ID'] = env('AUTH_OIDC_CLIENT_ID');
+$config['AUTH_OIDC_CLIENT_SECRET'] = env('AUTH_OIDC_CLIENT_SECRET');
 
 $config['LOG_SENT_MAIL'] = env_bool('LOG_SENT_MAIL');
 $config['AUTH_AUTO_CREATE'] = env_bool('AUTH_AUTO_CREATE');


### PR DESCRIPTION
Hello ! 

I've been using Awesome-TTRSS for some times now and thanks for the work you've made.

I submit this PR because I'd like to have OIDC authentication on Awesomme-TTRSS (with SSO feature) by adding this plugin : [Auth OIDC](https://dev.tt-rss.org/tt-rss/ttrss-auth-oidc)