### PR TITLE
Add support for FreshAPI Google Reader API Plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,11 @@ RUN mkdir auth_oidc && \
   curl -sL https://gitlab.tt-rss.org/tt-rss/plugins/ttrss-auth-oidc/-/archive/master/ttrss-auth-oidc-master.tar.gz | \
   tar xzvpf - --strip-components=1 -C auth_oidc ttrss-auth-oidc-master
 
+## FreshAPI
+RUN mkdir /var/www/plugins/freshapi && \
+  curl -sL https://github.com/eric-pierce/freshapi/archive/master.tar.gz | \
+  tar xzvpf - --strip-components=1 -C /var/www/plugins/freshapi freshapi-master
+
 # Download themes
 WORKDIR /var/www/themes.local
 

--- a/src/ttrss.nginx.conf
+++ b/src/ttrss.nginx.conf
@@ -35,5 +35,14 @@ http {
             fastcgi_index index.php;
             include fastcgi_params;
         }
+        location ~ /plugins\.local/.*/api/.*\.php(/|$) {
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            set $path_info $fastcgi_path_info;
+            fastcgi_param PATH_INFO $path_info;
+            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_index index.php;
+            include fastcgi_params;
+        }
     }
 }


### PR DESCRIPTION
Awesome-TTRSS is using an old standard for nginx.conf. This pull request adds support for PATH_INFO for the plugins directory similar to the recent merge to the official image [here](https://gitlab.tt-rss.org/tt-rss/tt-rss/-/merge_requests/61), and adds freshapi to the pre-packaged plugins list.