### PR TITLE
fix: Fix zombie process

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,6 +28,6 @@ if [ -n "$DB_USER_FILE" ]; then DB_USER="$(cat $DB_USER_FILE)"; fi
 
 if [ -n "$DB_PASS_FILE" ]; then DB_PASS="$(cat $DB_PASS_FILE)"; fi
 
-sh /wait-for.sh $DB_HOST:$DB_PORT -- php /initialize.php && sudo -E -u nobody php /var/www/update.php --update-schema=force-yes && exec s6-svscan /etc/s6/
+sh /wait-for.sh $DB_HOST:$DB_PORT -- php /initialize.php && s6-setuidgid nobody php /var/www/update.php --update-schema=force-yes && exec s6-svscan /etc/s6/
 
 exec "$@"


### PR DESCRIPTION
The original entry point creates a zombie process, as `sudo php /var/www/update.php`'s parent is replaced by `exec`

## Reproduce
```bash
> ps -eo pid,ppid,state,comm | awk '$3=="Z"'
   4753    3307 Z sudo

> cat /proc/4753/cgroup
0::/system.slice/docker-5af81bba29f94847eea71766e439d6f7a5a1a5a753750a659749c61220c9f10a.scope

> docker ps -a --filter "id=5af81bba"
CONTAINER ID   IMAGE                   COMMAND                  CREATED       STATUS        PORTS                                   NAMES
5af81bba29f9   wangqiru/ttrss:latest   "sh /docker-entrypoi…"   12 days ago   Up 22 hours   0.0.0.0:181->80/tcp, [::]:181->

> pstree -ap 3307
s6-svscan,3307 /etc/s6/
  ├─s6-supervise,4889 update-daemon
  │   └─php,4894 /var/www/update_daemon2.php
  │       └─php,2140468 /var/www/update_daemon2.php
  │           └─php,2140470 update.php --daemon-loop --log-level 0 --task 0 --pidlock 34426
  │               └─php,2140491 update.php --update-feed 478 --pidlock feed-478 --log-level 0
  ├─s6-supervise,4890 php-fpm
  │   └─php-fpm83,4895
  │       ├─php-fpm83,2116152
  │       ├─php-fpm83,2117825
  │       └─php-fpm83,2140661
  ├─s6-supervise,4891 nginx
  │   └─nginx,4893
  │       └─nginx,4930
  └─(sudo,4753)
```